### PR TITLE
Updated database objects to have a picture attribute

### DIFF
--- a/it122/index.js
+++ b/it122/index.js
@@ -97,9 +97,9 @@ app.set('view engine', 'ejs');
 
     //Add/update API route
     app.post('/api/pokemon', async (req, res) => {
-        const { name, category, type, dex_num, debut } = req.body;
+        const { name, category, type, dex_num, debut, picture } = req.body;
 
-        if (!name || !category || !type || !dex_num || !debut) {
+        if (!name || !category || !type || !dex_num || !debut || !picture) {
             return res.status(400).json({ error: 'Missing required fields' });
         }
 
@@ -113,17 +113,51 @@ app.set('view engine', 'ejs');
                 existingPokemon.type = type;
                 existingPokemon.dex_num = dex_num;
                 existingPokemon.debut = debut;
+                existingPokemon.picture = picture;
                 await existingPokemon.save();
                 return res.json({ message: 'Pokémon updated successfully', pokemon: existingPokemon });
             } else {
                 // Create new pokemon
-                const newPokemon = new Pokemon({ name, category, type, dex_num, debut });
+                const newPokemon = new Pokemon({ name, category, type, dex_num, debut, picture });
                 await newPokemon.save();
                 return res.status(201).json({ message: 'Pokémon created successfully', pokemon: newPokemon });
             }
         } catch (err) {
             console.error('Error saving Pokémon:', err);
             return res.status(500).json({ error: 'Internal Server Error' });
+        }
+    });
+
+    app.post('/api/pokemon', async (req, res) => {
+        const { name, category, type, dex_num, debut, picture } = req.body;
+    
+        // Validate required fields
+        if (!name || !category || !type || !dex_num || !debut || !picture) {
+            return res.status(400).json({ error: 'Missing required fields' });
+        }
+    
+        try {
+            // Check if pokemon exists based on name (and possibly category/type if needed)
+            const existingPokemon = await Pokemon.findOne({ name });
+    
+            if (existingPokemon) {
+                // Update existing Pokémon
+                existingPokemon.category = category;
+                existingPokemon.type = type;
+                existingPokemon.dex_num = dex_num;
+                existingPokemon.debut = debut;
+                existingPokemon.picture = picture;
+                await existingPokemon.save();
+                return res.json({ message: 'Pokémon updated successfully', pokemon: existingPokemon });
+            } else {
+                // Create new Pokémon if not found
+                const newPokemon = new Pokemon({ name, category, type, dex_num, debut, picture });
+                await newPokemon.save();
+                return res.status(201).json({ message: 'Pokémon created successfully', pokemon: newPokemon });
+            }
+        } catch (err) {
+            console.error('Error saving Pokémon:', err);
+            return res.status(500).json({ error: 'Internal Server Error', details: err.message });
         }
     });
 

--- a/it122/models/Pokemon.js
+++ b/it122/models/Pokemon.js
@@ -19,8 +19,9 @@ const pokemonSchema = new Schema({
  name: { type: String, required: true },
  category: String,
  type: Array,
- dexNum: Number,
- debut: String
+ dex_num: Number,
+ debut: String,
+ picture: String,
 });
 
 export const Pokemon = mongoose.model('Pokemon', pokemonSchema, 'pokemon');

--- a/it122/views/detail.ejs
+++ b/it122/views/detail.ejs
@@ -8,7 +8,7 @@
             <h2><%= result.name %></h2>
             </div>
 
-            <img src="images/<%= result.name %>.png" alt="<%= result.name %>" width="300" height="300">
+            <img src="<%= result.picture %>" alt="<%= result.name %>" width="300" height="300">
 
             <div>
             <li class="first"><b>Category:</b> <%= result.category %></li>


### PR DESCRIPTION
Pokemon objects now have a "picture" attribute that takes a string. The string should be a url link to a picture of the pokemon.

The "detail" view has been updated to display whatever picture is linked to in the "picture" URL. It used to look for a .png file in the "images" folder.

This update allows new Pokemon created with a POST request to have a picture, just like the existing entries, instead of having no picture because it doesn't exist in the "images" folder.